### PR TITLE
fix(sentry): json stringify the `variables` so they don't show up as Objects in logs

### DIFF
--- a/src/plugins/sentryPlugin.ts
+++ b/src/plugins/sentryPlugin.ts
@@ -38,7 +38,7 @@ export const sentryPlugin: ApolloServerPlugin = {
 
             // Log query and variables as extras (make sure to strip out sensitive data!)
             scope.setExtra('query', ctx.request.query);
-            scope.setExtra('variables', ctx.request.variables);
+            scope.setExtra('variables', JSON.stringify(ctx.request.variables));
 
             if (err.path) {
               // We can also add the path as breadcrumb


### PR DESCRIPTION
## Goal

Right now, the `variables` show up as list of [Objects] in sentry. https://sentry.io/organizations/pocket/issues/2749490961/?project=5591912&query=is%3Aunresolved&statsPeriod=30d

changing to JSON.stringify(variables) so we can see the actual values

 For ticket: https://getpocket.atlassian.net/browse/INFRA-195
