### PR TITLE
feat (cursor-pagination): move validate pagination to apollo-utils

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,4 @@ export * from './cache/ElasticacheRedis';
 export * from './plugins/sentryPlugin';
 export * from './dataloader';
 export * from './errorHandler/errorHandler';
+export * from './pagination/';

--- a/src/pagination/index.ts
+++ b/src/pagination/index.ts
@@ -1,0 +1,2 @@
+export { PaginationInput } from './types';
+export { validatePagination } from './validatePagination';

--- a/src/pagination/types.ts
+++ b/src/pagination/types.ts
@@ -1,0 +1,6 @@
+export type PaginationInput = {
+  after?: string;
+  before?: string;
+  first?: number;
+  last?: number;
+};

--- a/src/pagination/validatePagination.spec.ts
+++ b/src/pagination/validatePagination.spec.ts
@@ -1,0 +1,82 @@
+import { expect } from 'chai';
+import { validatePagination } from './validatePagination';
+
+describe('pagination validation', () => {
+  const defaultPageSize = 30;
+  const maxPageSize = 100;
+
+  it('should throw error if first and last are set', () => {
+    const pagination = { first: 100, last: 20 };
+    expect(() => validatePagination(pagination)).throw(
+      'Please set either {after and first} or {before and last}'
+    );
+  });
+
+  it('should throw error if before and after are set', () => {
+    const pagination = { before: 'b_cursor', after: 'a_cursor' };
+    expect(() => validatePagination(pagination)).throw(
+      'Please set either {after and first} or {before and last}'
+    );
+  });
+
+  it('should throw error if before and first are set', () => {
+    const pagination = { before: 'b_cursor', first: 20 };
+    expect(() => validatePagination(pagination)).throw(
+      'Please set either {after and first} or {before and last}'
+    );
+  });
+
+  it('should throw error when cursor is negative number', () => {
+    const before = Buffer.from('-1').toString('base64');
+    const pagination = { before: before, last: 10 };
+    expect(() =>
+      validatePagination(pagination, defaultPageSize, maxPageSize)
+    ).throw('Invalid before cursor');
+  });
+
+  it('should set last to default pagination size if before is set', () => {
+    const before = Buffer.from('10').toString('base64');
+    const actual = validatePagination(
+      { before: before },
+      defaultPageSize,
+      maxPageSize
+    );
+    expect(actual).to.deep.equal({ before: before, last: defaultPageSize });
+  });
+
+  it('should set last to default pagination size if its negative', () => {
+    const before = Buffer.from('10').toString('base64');
+    const actual = validatePagination(
+      { before: before, last: -20 },
+      defaultPageSize,
+      maxPageSize
+    );
+    expect(actual).to.deep.equal({ before: before, last: defaultPageSize });
+  });
+
+  it('should set first to default pagination size if its negative', () => {
+    const after = Buffer.from('10').toString('base64');
+    const actual = validatePagination({ after: after, first: -20 });
+    expect(actual).to.deep.equal({ after: after, first: defaultPageSize });
+  });
+
+  it('should set last to default pagination size if its negative', () => {
+    const actual = validatePagination({ last: -20 });
+    expect(actual).to.deep.equal({ last: defaultPageSize });
+  });
+
+  it('should set first to defaultPageSize if pagination is null', () => {
+    const actual = validatePagination(null, 50, 100);
+    expect(actual).to.deep.equal({ first: 50 });
+  });
+
+  it('should set first to maxPageSize if its greater than maxPageSize', () => {
+    const actual = validatePagination({ first: 200 }, 40, 200);
+    expect(actual).to.deep.equal({ first: 200 });
+  });
+
+  it('should set last to maxPageSize if its greater than maxPageSize', () => {
+    const actual = validatePagination({ last: 200 });
+    expect(actual).to.deep.equal({ last: maxPageSize });
+  });
+});

--- a/src/pagination/validatePagination.ts
+++ b/src/pagination/validatePagination.ts
@@ -1,0 +1,65 @@
+import { UserInputError } from 'apollo-server-errors';
+import { PaginationInput } from './types';
+
+export function validatePagination(
+  pagination: PaginationInput,
+  defaultPageSize = 30,
+  maxPageSize = 100
+): PaginationInput {
+  if (pagination == null) {
+    return { first: defaultPageSize };
+  }
+
+  if (
+    (pagination.before && pagination.after) ||
+    (pagination.before && pagination.first) ||
+    (pagination.last && pagination.after) ||
+    (pagination.first && pagination.last)
+  ) {
+    throw new UserInputError(
+      'Please set either {after and first} or {before and last}'
+    );
+  }
+
+  if (pagination.before) {
+    const before = parseInt(
+      Buffer.from(pagination.before, 'base64').toString()
+    );
+    if (before < 0) {
+      throw new UserInputError('Invalid before cursor');
+    }
+
+    if (!pagination.last) {
+      pagination.last = defaultPageSize;
+    }
+  }
+
+  if (pagination.after) {
+    const after = parseInt(Buffer.from(pagination.after, 'base64').toString());
+    if (after < 0) {
+      throw new UserInputError('Invalid after cursor');
+    }
+
+    if (!pagination.first) {
+      pagination.first = defaultPageSize;
+    }
+  }
+
+  if (pagination.first <= 0) {
+    pagination.first = defaultPageSize;
+  }
+
+  if (pagination.last <= 0) {
+    pagination.last = defaultPageSize;
+  }
+
+  if (pagination.first > maxPageSize) {
+    pagination.first = maxPageSize;
+  }
+
+  if (pagination.last > maxPageSize) {
+    pagination.last = maxPageSize;
+  }
+
+  return pagination;
+}


### PR DESCRIPTION
## Goal

move the list-api validate pagination logic to apollo-utils so we can share it between list api and user-list search

paired with @nina-py 
