### PR TITLE
fix: stop logging client errors and NOT_FOUND errors in sentry & cloudwatch

### DIFF
--- a/src/errorHandler/errorHandler.spec.ts
+++ b/src/errorHandler/errorHandler.spec.ts
@@ -111,13 +111,9 @@ describe('Server error handling: ', () => {
     // Just passing through, so check if not undefined
     expect(error.path).to.not.be.undefined;
     expect(error.locations).to.not.be.undefined;
-    // Check the original error got logged and sent to sentry
+    //not logging not-found errors
     [consoleSpy, sentrySpy].forEach((spy) => {
-      expect(spy.calledOnce).to.be.true;
-      expect(spy.getCall(0).args[0].message).to.equal(
-        'Error - Not Found: book id'
-      );
-      expect(spy.getCall(0).args[0].stack).to.not.be.undefined;
+      expect(spy.callCount).to.equal(0);
     });
   });
   it('Can handle multiple errors and still resolve data', async () => {
@@ -192,12 +188,9 @@ describe('Server error handling: ', () => {
     const res = await server.executeOperation({ query });
     expect(res.errors.length).to.equal(1);
     expect(res.errors[0].message).to.contain('Bad input');
-    // Check the original error got logged and sent to sentry
-    // This is raised during the resolver, so will trigger sending errors
+    // user error - shouldn't be logged
     [consoleSpy, sentrySpy].forEach((spy) => {
-      expect(spy.calledOnce).to.be.true;
-      expect(spy.getCall(0).args[0].message).to.contain('Bad input');
-      expect(spy.getCall(0).args[0].stack).to.not.be.undefined;
+      expect(spy.callCount).to.equal(0);
     });
   });
 });

--- a/src/errorHandler/errorHandler.ts
+++ b/src/errorHandler/errorHandler.ts
@@ -24,8 +24,9 @@ export function errorHandler(error: GraphQLError): GraphQLError {
 }
 
 export class NotFoundError extends Error {
+  static errorPrefix: string = `Error - Not Found`;
   constructor(message?: string) {
-    super(`Error - Not Found: ${message}`); // 'Error' breaks prototype chain here
+    super(`${NotFoundError.errorPrefix}: ${message}`); // 'Error' breaks prototype chain here
     Object.setPrototypeOf(this, new.target.prototype); // restore prototype chain
   }
 }

--- a/src/errorHandler/errorHandler.ts
+++ b/src/errorHandler/errorHandler.ts
@@ -24,7 +24,7 @@ export function errorHandler(error: GraphQLError): GraphQLError {
 }
 
 export class NotFoundError extends Error {
-  static errorPrefix: string = `Error - Not Found`;
+  static errorPrefix = `Error - Not Found`;
   constructor(message?: string) {
     super(`${NotFoundError.errorPrefix}: ${message}`); // 'Error' breaks prototype chain here
     Object.setPrototypeOf(this, new.target.prototype); // restore prototype chain

--- a/src/plugins/sentryPlugin.ts
+++ b/src/plugins/sentryPlugin.ts
@@ -1,5 +1,6 @@
 import * as Sentry from '@sentry/node';
 import { ApolloServerPlugin } from 'apollo-server-plugin-base';
+import { NotFoundError } from '../errorHandler/errorHandler';
 
 /**
  * Plugin for handling errors.
@@ -41,7 +42,7 @@ export const sentryPlugin: ApolloServerPlugin = {
             //the error-handler is called after sentryPlugin,
             //so we won't have `code` populated yet
             //so we are string matching with `NotFoundError` class message prefix
-            err.message.includes('Error - Not Found')
+            err.message.includes(NotFoundError.errorPrefix)
           ) {
             continue;
           }

--- a/src/plugins/sentryPlugin.ts
+++ b/src/plugins/sentryPlugin.ts
@@ -39,10 +39,7 @@ export const sentryPlugin: ApolloServerPlugin = {
           // all errors extending ApolloError should be user-facing
           if (
             errorCodes.includes(err.extensions?.code?.toString()) ||
-            //the error-handler is called after sentryPlugin,
-            //so we won't have `code` populated yet
-            //so we are string matching with `NotFoundError` class message prefix
-            err.message.includes(NotFoundError.errorPrefix)
+            err.originalError instanceof NotFoundError
           ) {
             continue;
           }

--- a/src/plugins/sentryPlugin.ts
+++ b/src/plugins/sentryPlugin.ts
@@ -1,5 +1,4 @@
 import * as Sentry from '@sentry/node';
-import { ApolloError } from 'apollo-server-errors';
 import { ApolloServerPlugin } from 'apollo-server-plugin-base';
 
 /**
@@ -18,6 +17,16 @@ export const sentryPlugin: ApolloServerPlugin = {
                  to request-specific lifecycle events. */
     return {
       async didEncounterErrors(ctx) {
+        //for error codes:
+        // https://www.apollographql.com/docs/apollo-server/data/errors/#bad_user_input
+        const errorCodes = [
+          'FORBIDDEN',
+          'UNAUTHENTICATED',
+          'BAD_USER_INPUT',
+          'GRAPHQL_PARSE_FAILED',
+          'GRAPHQL_VALIDATION_FAILED',
+        ];
+
         // If we couldn't parse the operation, don't
         // do anything here
         if (!ctx.operation) {
@@ -27,7 +36,13 @@ export const sentryPlugin: ApolloServerPlugin = {
         for (const err of ctx.errors) {
           // Only report internal server errors,
           // all errors extending ApolloError should be user-facing
-          if (err instanceof ApolloError) {
+          if (
+            errorCodes.includes(err.extensions?.code?.toString()) ||
+            //the error-handler is called after sentryPlugin,
+            //so we won't have `code` populated yet
+            //so we are string matching with `NotFoundError` class message prefix
+            err.message.includes('Error - Not Found')
+          ) {
             continue;
           }
 


### PR DESCRIPTION
## Goal

fix: stop logging client errors and NOT_FOUND errors in sentry & cloudwatch

### Implementation details/feedback on: 
- the existing `instanceOf ApolloError` implementation didn't work as the objects were of type `Error` at runtime and the `if` condition failed.  so made use of ApolloError's code to check the error type.
- for NOT_FOUND errors, the `code` will not be populated yet as the `errorHandler()` is called after `sentryPlugin`. so made use of messasge prefix, which is hard-coded in `NotFoundError` class. 
- looks slightly hacky but relying on test to catch errors. 

Ticket: https://getpocket.atlassian.net/browse/INFRA-689 